### PR TITLE
feat: add general signup feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/mumage/mumagebackend/Config/SpringConfig.java
+++ b/src/main/java/mumage/mumagebackend/Config/SpringConfig.java
@@ -1,0 +1,24 @@
+package mumage.mumagebackend.Config;
+
+import mumage.mumagebackend.repository.MemberRepository;
+import mumage.mumagebackend.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringConfig {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public SpringConfig(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Bean
+    public MemberService memberService() {
+        return new MemberService(memberRepository);
+    }
+
+}

--- a/src/main/java/mumage/mumagebackend/Config/SwaggerConfig.java
+++ b/src/main/java/mumage/mumagebackend/Config/SwaggerConfig.java
@@ -16,9 +16,7 @@ public class SwaggerConfig {
     }
 
     private Info apiInfo() {
-        return new Info()
-                .title("Springdoc 테스트")
-                .description("Springdoc을 사용한 Swagger UI 테스트")
+        return new Info().title("Mumage backend test").description("Mumage backend test UI 테스트")
                 .version("1.0.0");
     }
 }

--- a/src/main/java/mumage/mumagebackend/controller/MemberController.java
+++ b/src/main/java/mumage/mumagebackend/controller/MemberController.java
@@ -1,0 +1,41 @@
+package mumage.mumagebackend.controller;
+
+import jakarta.validation.Valid;
+import mumage.mumagebackend.domain.Member;
+import mumage.mumagebackend.dto.MemberJoinDto;
+import mumage.mumagebackend.repository.MemberRepository;
+import mumage.mumagebackend.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping(value = "/api/signup")
+    public Member joinMember(@Valid @RequestBody MemberJoinDto memberJoinDto) {
+
+        Member member = memberService.join(memberJoinDto);
+        return member;
+
+    }
+
+    @DeleteMapping(value = "/api/user/{id}")
+    public ResponseEntity<Void> withdrawMember(@PathVariable Long id) {
+        if (memberService.withdraw(id)) {
+            return ResponseEntity.ok().build();
+        } else {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+}

--- a/src/main/java/mumage/mumagebackend/domain/Member.java
+++ b/src/main/java/mumage/mumagebackend/domain/Member.java
@@ -1,0 +1,29 @@
+package mumage.mumagebackend.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "member")
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, length = 15)
+    private String memberId;
+    @Column(nullable = false, length = 15)
+    private String password;
+    @Column(nullable = false, length = 10)
+    private String name;
+    @Column(nullable = false, length = 15)
+    private String nickname;
+
+}

--- a/src/main/java/mumage/mumagebackend/dto/ExceptionResponseDto.java
+++ b/src/main/java/mumage/mumagebackend/dto/ExceptionResponseDto.java
@@ -1,0 +1,20 @@
+package mumage.mumagebackend.dto;
+
+import lombok.Getter;
+import mumage.mumagebackend.exception.ErrCode;
+
+@Getter
+public class ExceptionResponseDto {
+    private final int status;
+    private final Object message;
+
+    public ExceptionResponseDto(int status, Object message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public ExceptionResponseDto(ErrCode errCode) {
+        this.message = errCode.getMessage();
+        this.status = errCode.getStatus();
+    }
+}

--- a/src/main/java/mumage/mumagebackend/dto/MemberJoinDto.java
+++ b/src/main/java/mumage/mumagebackend/dto/MemberJoinDto.java
@@ -1,0 +1,22 @@
+package mumage.mumagebackend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberJoinDto {
+
+    @NotBlank @Size(min = 5, max = 15) @Pattern(regexp = "^[0-9a-zA-Z]*$")
+    private String memberId;
+    @NotBlank @Size(min = 8, max = 15) @Pattern(regexp = "^[0-9a-zA-Z!@#$%^&+=]*$")
+    private String password;
+    @NotBlank @Size(min = 2, max = 10) @Pattern(regexp = "^[a-zA-Z가-힣]*$")
+    private String name;
+    @NotBlank @Size(min = 1, max = 15) @Pattern(regexp = "^[0-9a-zA-Z가-힣]*$")
+    private String nickname;
+
+}

--- a/src/main/java/mumage/mumagebackend/exception/CustomException.java
+++ b/src/main/java/mumage/mumagebackend/exception/CustomException.java
@@ -1,0 +1,19 @@
+package mumage.mumagebackend.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrCode errCode;
+    private final HttpStatus httpStatus;
+
+    public CustomException(final ErrCode errCode, final HttpStatus httpStatus) {
+        super(errCode.getMessage());
+        this.errCode = errCode;
+        this.httpStatus = httpStatus;
+    }
+
+
+}

--- a/src/main/java/mumage/mumagebackend/exception/ErrCode.java
+++ b/src/main/java/mumage/mumagebackend/exception/ErrCode.java
@@ -1,0 +1,18 @@
+package mumage.mumagebackend.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrCode {
+    INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST.value(), "비밀번호 형식이 잘못되었습니다."),
+    INVALID_NAME_FORMAT(HttpStatus.BAD_REQUEST.value(), "이름 형식이 잘못되었습니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST.value(), "닉네임 형식이 잘못되었습니다."),
+    DUPLICATED_ID(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 아이디입니다."),
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 닉네임입니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/mumage/mumagebackend/exception/RestControllerAdvisor.java
+++ b/src/main/java/mumage/mumagebackend/exception/RestControllerAdvisor.java
@@ -1,0 +1,37 @@
+package mumage.mumagebackend.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import mumage.mumagebackend.dto.ExceptionResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+
+@RestControllerAdvice
+@Slf4j
+public class RestControllerAdvisor {
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponseDto> handlerMethodArgumentNotValidException(MethodArgumentNotValidException methodArgumentNotValidException) {
+        BindingResult bindingResult = methodArgumentNotValidException.getBindingResult();
+        log.warn(methodArgumentNotValidException.getMessage());
+        HashMap<String, String> response = new HashMap<>();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            String responseMessage = fieldError.getDefaultMessage() + ", 입력된 값 : [" + fieldError.getRejectedValue() + "]";
+            response.put(fieldError.getField(), responseMessage);
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ExceptionResponseDto(HttpStatus.BAD_REQUEST.value(), response));
+    }
+
+    @ExceptionHandler(value = CustomException.class)
+    public ResponseEntity<ExceptionResponseDto> handlerCustomeException(CustomException customException) {
+        log.warn(customException.getMessage());
+        return ResponseEntity.status(customException.getHttpStatus()).body(new ExceptionResponseDto(customException.getErrCode()));
+    }
+
+}

--- a/src/main/java/mumage/mumagebackend/repository/MemberRepository.java
+++ b/src/main/java/mumage/mumagebackend/repository/MemberRepository.java
@@ -1,0 +1,17 @@
+package mumage.mumagebackend.repository;
+
+import mumage.mumagebackend.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByMemberId(String memberId);
+
+    Optional<Member> findByName(String name);
+
+    Optional<Member> findByNickname(String nickname);
+
+
+}

--- a/src/main/java/mumage/mumagebackend/service/MemberService.java
+++ b/src/main/java/mumage/mumagebackend/service/MemberService.java
@@ -1,0 +1,91 @@
+package mumage.mumagebackend.service;
+
+import mumage.mumagebackend.domain.Member;
+import mumage.mumagebackend.dto.MemberJoinDto;
+import mumage.mumagebackend.exception.CustomException;
+import mumage.mumagebackend.exception.ErrCode;
+import mumage.mumagebackend.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Transactional
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    /*
+    회원 가입 : create
+     */
+    public Member join(MemberJoinDto memberJoinDto) {
+
+        Member member = new Member();
+        member.setMemberId(memberJoinDto.getMemberId());
+        member.setPassword(memberJoinDto.getPassword());
+        member.setName(memberJoinDto.getName());
+        member.setNickname(memberJoinDto.getNickname());
+
+        // 중복 조회
+        validateDuplicateId(member); // 아이디
+        validateDuplicateNickname(member); // 닉네임
+
+
+        memberRepository.save(member);
+        return member;
+    }
+
+    /*
+    회원 탈퇴 : delete
+     */
+    public Boolean withdraw(Long id) {
+        Optional<Member> member = memberRepository.findById(id);
+        if (member.isPresent()) {
+            memberRepository.delete(member.get());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /*
+    중복 조회
+     */
+
+    // 아이디
+    private void validateDuplicateId(Member member) {
+        memberRepository.findByMemberId(member.getMemberId()).ifPresent(m -> {
+            throw new CustomException(ErrCode.DUPLICATED_ID, HttpStatus.BAD_REQUEST);
+        });
+    }
+
+    // 닉네임
+    private void validateDuplicateNickname(Member member) {
+        memberRepository.findByNickname(member.getNickname()).ifPresent(m -> {
+            throw new CustomException(ErrCode.DUPLICATED_NICKNAME, HttpStatus.BAD_REQUEST);
+        });
+    }
+
+
+    /*
+    전체 회원 조회
+     */
+    public List<Member> findMembers() {
+        return memberRepository.findAll();
+    }
+
+    /*
+    특정 회원 조회
+     */
+    public Optional<Member> findOne(Long memberId) {
+        return memberRepository.findById(memberId);
+    }
+
+}

--- a/src/test/java/mumage/mumagebackend/service/MemberServiceTest.java
+++ b/src/test/java/mumage/mumagebackend/service/MemberServiceTest.java
@@ -1,0 +1,100 @@
+package mumage.mumagebackend.service;
+
+import mumage.mumagebackend.domain.Member;
+import mumage.mumagebackend.dto.MemberJoinDto;
+import mumage.mumagebackend.exception.CustomException;
+import mumage.mumagebackend.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired MemberRepository memberRepository;
+    @Autowired MemberService memberService;
+
+    @Test
+    public void 회원가입() throws Exception {
+
+        // post로 memberJoinDto를 받는다.
+        MemberJoinDto memberJoinDto = new MemberJoinDto();
+        memberJoinDto.setMemberId("mumage_id");
+        memberJoinDto.setPassword("mumage_pw");
+        memberJoinDto.setName("mumage");
+        memberJoinDto.setNickname("mumage_nn");
+
+        // join 실행 / join return -> Member / 결과값에 getId()로 id를 가져온다.
+        Long saveId = memberService.join(memberJoinDto).getId();
+
+        // 저장된 회원 정보 sout
+        System.out.println("회원아이디 = " + memberJoinDto.getMemberId());
+        System.out.println("회원이름 = " + memberJoinDto.getName());
+        System.out.println("회원닉네임 = " + memberJoinDto.getNickname());
+        System.out.println("회원패스워드 = " + memberJoinDto.getPassword());
+
+        // saveId로 member를 찾아서 저장한 member와 같은지 확인한다.
+        Member findMember = memberRepository.findById(saveId).get();
+        assertEquals(memberJoinDto.getName(), findMember.getName());
+
+    }
+
+    @Test
+    public void 회원가입_아이디_중복() {
+
+        MemberJoinDto member1 = new MemberJoinDto();
+        member1.setMemberId("mumage_id");
+        member1.setPassword("mumage_pw1");
+        member1.setName("mumage1");
+        member1.setNickname("mumage_nn1");
+
+        MemberJoinDto member2 = new MemberJoinDto();
+        member2.setMemberId("mumage_id");
+        member2.setPassword("mumage_pw2");
+        member2.setName("mumage2");
+        member2.setNickname("mumage_nn2");
+
+        memberService.join(member1);
+
+        CustomException exception = assertThrows(CustomException.class, () -> memberService.join(member2));
+        assertThat(exception.getMessage()).isEqualTo("이미 존재하는 아이디입니다.");
+
+    }
+
+    @Test
+    public void 회원가입_중복닉네임() {
+
+        MemberJoinDto member1 = new MemberJoinDto();
+        member1.setMemberId("mumage_id1");
+        member1.setPassword("mumage_pw1");
+        member1.setName("mumage1");
+        member1.setNickname("mumage_nn");
+
+        MemberJoinDto member2 = new MemberJoinDto();
+        member2.setMemberId("mumage_id2");
+        member2.setPassword("mumage_pw2");
+        member2.setName("mumage2");
+        member2.setNickname("mumage_nn");
+
+        memberService.join(member1);
+
+        CustomException exception = assertThrows(CustomException.class, () -> memberService.join(member2));
+        assertThat(exception.getMessage()).isEqualTo("이미 존재하는 닉네임입니다.");
+
+    }
+
+    public void 닉네임변경() {
+
+    }
+
+    public void 닉네임변경_중복닉네임() {
+
+    }
+
+}


### PR DESCRIPTION
# 1. 회원가입 - signup

## 1.1. 정상 동작

![회원가입post](https://github.com/Musicstagram/mumage-backend/assets/83761128/ed5ffc95-79f7-4f08-be11-f94d361cbb3c)

![정상등록](https://github.com/Musicstagram/mumage-backend/assets/83761128/3cd988c4-40cb-4de9-aa6a-590027c9241c)

- DB에 정상적으로 저장

- url : `http://localhost:8080/api/signup`

- JSON
  
  - input {"memberId", "password", "name", "nickname"}
  
  - output {"id" , "memberId" , password", "name" , "nickname"}

## 1.2. 예외 처리

### 1.2.1. 중복

- 아이디
  
![회원가입중복아이디](https://github.com/Musicstagram/mumage-backend/assets/83761128/bac8e9ce-23b9-4a37-a6b5-5b81f5d9aaaf)

- 닉네임
  
![회원가입중복닉네임](https://github.com/Musicstagram/mumage-backend/assets/83761128/ec93cf24-8bee-4d71-91d0-08c565bc27af)

### 1.2.2. 문자열 크기(길이)

![회원가입예외크기](https://github.com/Musicstagram/mumage-backend/assets/83761128/fc2310a7-1e30-4c44-8608-2faf9c061991)

### 1.2.3. 사용 문자 제한

- 아이디 : 숫자, 영문(대/소)

- 비밀번호 : 숫자, 영문(대/소), 특수문자(!@#$%^&+=)

- 이름 : 영문(대/소), 한글

- 닉네임 : 숫자, 영문(대/소), 한글

![회원가입예외문자](https://github.com/Musicstagram/mumage-backend/assets/83761128/b44a97b6-a910-46f2-bb75-a43760e060a2)

# 2. 회원가입 - withdraw

![회원탈퇴](https://github.com/Musicstagram/mumage-backend/assets/83761128/6c00d60d-e020-4de0-8e91-ab3fe269f3fb)

![정상삭제](https://github.com/Musicstagram/mumage-backend/assets/83761128/fde64e36-bb2e-48fe-8f67-c1293543f02d)

- DB에 정상적으로 삭제

- url : `http://localhost:8080/api/user/{id}`

# 3. 기타

- 유효성 검사를 위한 dependency 추가
  
  `implementation 'org.springframework.boot:spring-boot-starter-validation'`
